### PR TITLE
Workflow uninstall

### DIFF
--- a/puppetplays-admin/composer.json
+++ b/puppetplays-admin/composer.json
@@ -8,7 +8,6 @@
     "ether/tags": "^2.0.0",
     "mmikkel/incognito-field": "^1.3.0",
     "nystudio107/craft-seomatic": "^4.1.12",
-    "verbb/workflow": "2.0.15",
     "vlucas/phpdotenv": "^3.4.0"
   },
   "require-dev": {

--- a/puppetplays-admin/composer.lock
+++ b/puppetplays-admin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "032136bcf118aa9c33448bdfa2aeedad",
+    "content-hash": "386e2077c4f32ae08638f8a07db88ec2",
     "packages": [
         {
             "name": "besteadfast/craft-preparse-field",
@@ -1400,71 +1400,6 @@
                 "source": "https://github.com/defuse/php-encryption/tree/v2.4.0"
             },
             "time": "2023-06-19T06:10:36+00:00"
-        },
-        {
-            "name": "diff/diff",
-            "version": "3.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wmde/Diff.git",
-                "reference": "19e5c8871868210ef2943c92bd7c223555b50b3f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wmde/Diff/zipball/19e5c8871868210ef2943c92bd7c223555b50b3f",
-                "reference": "19e5c8871868210ef2943c92bd7c223555b50b3f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "mediawiki/mediawiki-codesniffer": "^45",
-                "ockcyp/covers-validator": "~1.0",
-                "phpunit/phpunit": "~8.5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "Diff.php"
-                ],
-                "psr-4": {
-                    "Diff\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jeroen De Dauw",
-                    "email": "jeroendedauw@gmail.com",
-                    "homepage": "https://www.entropywins.wtf",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Small standalone library for representing differences between data structures, computing such differences, and applying them as patches",
-            "homepage": "https://github.com/wmde/Diff",
-            "keywords": [
-                "diff",
-                "diffing",
-                "diffop",
-                "patch",
-                "patching",
-                "wikidata"
-            ],
-            "support": {
-                "irc": "irc://irc.freenode.net/wikimedia-de-tech",
-                "issues": "https://github.com/wmde/Diff/issues",
-                "source": "https://github.com/wmde/Diff/tree/3.4.0"
-            },
-            "time": "2025-01-06T09:05:22+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -6607,121 +6542,6 @@
                 }
             ],
             "time": "2024-11-17T15:59:19+00:00"
-        },
-        {
-            "name": "verbb/base",
-            "version": "2.0.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/verbb/verbb-base.git",
-                "reference": "47a2671ef8862236b19609fe8409f11843aee1cf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/verbb/verbb-base/zipball/47a2671ef8862236b19609fe8409f11843aee1cf",
-                "reference": "47a2671ef8862236b19609fe8409f11843aee1cf",
-                "shasum": ""
-            },
-            "require": {
-                "craftcms/cms": "^4.0.0",
-                "php": "^8.0.2"
-            },
-            "type": "yii-module",
-            "autoload": {
-                "psr-4": {
-                    "verbb\\base\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Verbb",
-                    "homepage": "https://verbb.io"
-                }
-            ],
-            "description": "Common utilities and building-blocks for Verbb plugins for Craft CMS.",
-            "support": {
-                "docs": "https://github.com/verbb/verbb-base",
-                "email": "support@verbb.io",
-                "issues": "https://github.com/verbb/verbb-base/issues?state=open",
-                "rss": "https://github.com/verbb/verbb-base/commits/v2.atom",
-                "source": "https://github.com/verbb/verbb-base"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/verbb",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-11-13T00:05:42+00:00"
-        },
-        {
-            "name": "verbb/workflow",
-            "version": "2.0.15",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/verbb/workflow.git",
-                "reference": "3389742376857d109cf0f23405ed92cb9c9b95ee"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/verbb/workflow/zipball/3389742376857d109cf0f23405ed92cb9c9b95ee",
-                "reference": "3389742376857d109cf0f23405ed92cb9c9b95ee",
-                "shasum": ""
-            },
-            "require": {
-                "craftcms/cms": "^4.0.0",
-                "diff/diff": "^3.3",
-                "php": "^8.0.2",
-                "verbb/base": "^2.0.0"
-            },
-            "type": "craft-plugin",
-            "extra": {
-                "name": "Workflow",
-                "class": "verbb\\workflow\\Workflow",
-                "handle": "workflow",
-                "changelogUrl": "https://raw.githubusercontent.com/verbb/workflow/craft-4/CHANGELOG.md"
-            },
-            "autoload": {
-                "psr-4": {
-                    "verbb\\workflow\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "proprietary"
-            ],
-            "authors": [
-                {
-                    "name": "Verbb",
-                    "homepage": "https://verbb.io"
-                }
-            ],
-            "description": "Enforce multi-step review processes for creating entries.",
-            "keywords": [
-                "Craft",
-                "cms",
-                "craft-plugin",
-                "craftcms",
-                "workflow"
-            ],
-            "support": {
-                "docs": "https://github.com/verbb/workflow",
-                "email": "support@verbb.io",
-                "issues": "https://github.com/verbb/workflow/issues?state=open",
-                "rss": "https://github.com/verbb/workflow/commits/v2.atom",
-                "source": "https://github.com/verbb/workflow"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/verbb",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-03-04T00:09:28+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
Workflow plugin is causing an error:
`You need to be on at least Workflow 1.7.0 before you can update to Workflow 2.0.15.`

For now, we uninstall it to be able to access to the panel.