### PR TITLE
fix: Remove problematic global PHP location causing 'No input file sp…

### DIFF
--- a/puppetplays-deploy/nginx/prod-web.conf
+++ b/puppetplays-deploy/nginx/prod-web.conf
@@ -17,6 +17,9 @@ server {
 
     include conf/ssl.conf;
 
+    # Root par défaut pour éviter les erreurs
+    root /var/www/puppetplays.eu;
+
     location /.well-known {
         allow all;
         alias /var/www/puppetplays.eu/.well-known;
@@ -44,12 +47,8 @@ server {
         }
     }
 
-    # Gestion PHP globale pour Craft CMS et autres routes
-    location ~ \.php$ {
-        fastcgi_pass unix:/var/run/php/php7.3-fpm.sock;
-        fastcgi_index index.php;
-        include fastcgi.conf;
-    }
+    # SUPPRIMÉ : La location PHP globale qui causait le problème
+    # Toutes les requêtes PHP (sauf /projet) doivent aller vers le container Craft CMS via proxy
 
 }
 

--- a/puppetplays-deploy/nginx/staging-web.conf
+++ b/puppetplays-deploy/nginx/staging-web.conf
@@ -16,6 +16,9 @@ server {
 
     include conf/ssl.conf;
 
+    # Root par défaut pour éviter les erreurs
+    root /var/www/staging.puppetplays.eu;
+
     location /.well-known {
         allow all;
         alias /var/www/staging.puppetplays.eu/.well-known;
@@ -43,12 +46,8 @@ server {
         }
     }
 
-    # Gestion PHP globale pour Craft CMS et autres routes
-    location ~ \.php$ {
-        fastcgi_pass unix:/var/run/php/php7.3-fpm.sock;
-        fastcgi_index index.php;
-        include fastcgi.conf;
-    }
+    # SUPPRIMÉ : La location PHP globale qui causait le problème
+    # Toutes les requêtes PHP (sauf /projet) doivent aller vers le container Craft CMS via proxy
 
 }
 


### PR DESCRIPTION
…ecified' error - Remove global PHP location that was intercepting Docker-proxied requests - Add default root directive at server level - Keep PHP handling only for local /projet (Bludit) installation - Craft CMS requests properly proxied to Docker container