### PR TITLE
Disable settings from production

### DIFF
--- a/puppetplays-admin/config/general.php
+++ b/puppetplays-admin/config/general.php
@@ -74,7 +74,7 @@ return [
     // Production environment settings
     'production' => [
         // Set this to `false` to prevent administrative changes from being made on Production
-        'allowAdminChanges' => true,
+        'allowAdminChanges' => false,
 
         // Don’t allow updates on Production
         'allowUpdates' => false,


### PR DESCRIPTION
Disabling settings from production to prevent project missconfiguration