### PR TITLE
Fix PDF download error by handling non-string content types

### DIFF
--- a/puppetplays-admin/config/project/graphql/schemas/b203ce66-4f2e-4fab-a0be-e3b6d42f7e41.yaml
+++ b/puppetplays-admin/config/project/graphql/schemas/b203ce66-4f2e-4fab-a0be-e3b6d42f7e41.yaml
@@ -47,8 +47,8 @@ scope:
   - 'sections.e205ebe8-5557-4b7c-a43f-9cf548e90c8d:read' # Pays
   - 'entrytypes.bd5e6b34-8b0b-4a47-93f3-f9a23c0a39aa:read' # Pays
   - 'sections.63ea829e-b0e4-4021-8ab5-1b0f095d3daf:read' # Personnes
-  - 'entrytypes.8e095ccd-7ed1-4c9b-99e1-b98480a0e9df:read' # Compagnies
   - 'entrytypes.e0954bb8-d8bb-4fbb-b5e7-944b482e521e:read' # Personnes
+  - 'entrytypes.8e095ccd-7ed1-4c9b-99e1-b98480a0e9df:read' # Compagnies
   - 'sections.ccd48638-f531-4032-a057-8af4f24cd187:read' # Procédés théâtraux
   - 'entrytypes.5e83af75-a401-46c6-918f-f56ab78ad797:read' # Procédés théâtraux
   - 'sections.e555024e-2651-4c00-9772-7c3b197dc24a:read' # Projets de Recherche

--- a/puppetplays-web/components/TranscriptionPDFDownload.js
+++ b/puppetplays-web/components/TranscriptionPDFDownload.js
@@ -25,7 +25,28 @@ const TranscriptionPDFDownload = ({
   const cleanText = useCallback(text => {
     if (!text) return '';
 
-    return text
+    // Handle different input types
+    let stringValue = '';
+
+    if (typeof text === 'string') {
+      stringValue = text;
+    } else if (text && typeof text === 'object') {
+      // If it's an object, try to extract content property
+      if (text.content && typeof text.content === 'string') {
+        stringValue = text.content;
+      } else if (text.toString) {
+        // Fallback to toString if available
+        stringValue = text.toString();
+      } else {
+        // Last resort: convert to string
+        stringValue = String(text);
+      }
+    } else {
+      // Convert any other type to string
+      stringValue = String(text);
+    }
+
+    return stringValue
       .replace(/\r\n/g, '\n') // Normalise les retours à la ligne Windows
       .replace(/\r/g, '\n') // Normalise les retours à la ligne Mac
       .replace(/\n\s+/g, ' ') // Remplace retour à la ligne + espaces par un seul espace

--- a/puppetplays-web/test-places-staging.js
+++ b/puppetplays-web/test-places-staging.js
@@ -107,3 +107,5 @@ req.on('error', error => {
 req.write(data);
 req.end();
 
+
+


### PR DESCRIPTION
- Add type checking and conversion in cleanText function
- Handle objects with content property properly
- Ensure all input types are converted to strings before applying replace operations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevent PDF generation errors by converting various input types to strings in `cleanText` and normalizing whitespace.
> 
> - **Web**:
>   - **Transcription PDF**: Enhance `cleanText` in `components/TranscriptionPDFDownload.js` to handle non-string inputs (objects with `content`, `toString`, etc.) before applying normalization.
> - **Config**:
>   - **GraphQL Public Schema**: Minor scope list adjustment involving `entrytypes.8e095ccd-7ed1-4c9b-99e1-b98480a0e9df` (Compagnies).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e11d926ffb4ebac029c86e989d8626b7b696050c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->