### PR TITLE
Add contributor field to work notices

### DIFF
--- a/puppetplays-web/components/Work/Work.js
+++ b/puppetplays-web/components/Work/Work.js
@@ -432,6 +432,13 @@ function Work(props) {
           </div>
         </Section>
 
+        <Section
+          title={t('common:writtenBy')}
+          show={writtenBy && (!!writtenBy.firstName || !!writtenBy.lastName)}
+        >
+          {writtenBy?.firstName} {writtenBy?.lastName}
+        </Section>
+
         {/* Translator field from GraphQL plain text field */}
         {/* Display translatedBy Users if available, otherwise fallback to translatedByGraphql */}
         <Section
@@ -456,13 +463,6 @@ function Work(props) {
           ) : (
             translatedByGraphql
           )}
-        </Section>
-
-        <Section
-          title={t('common:writtenBy')}
-          show={writtenBy && (!!writtenBy.firstName || !!writtenBy.lastName)}
-        >
-          {writtenBy?.firstName} {writtenBy?.lastName}
         </Section>
       </div>
     </article>

--- a/puppetplays-web/lib/api.js
+++ b/puppetplays-web/lib/api.js
@@ -381,6 +381,13 @@ query GetWorkById($locale: [String], $id: [QueryArgument]) {
   entry(section: "works", site: $locale, id: $id) {
     id,
     title,
+    author {
+      id,
+      fullName,
+      firstName,
+      lastName,
+      email
+    },
     ... on works_works_Entry {
       doi,
       viafId,

--- a/puppetplays-web/pages/oeuvres/[id]/[slug].js
+++ b/puppetplays-web/pages/oeuvres/[id]/[slug].js
@@ -108,7 +108,7 @@ const WorkPage = ({ initialData }) => {
           />
         </div>
         <ContentLayout style={{ maxWidth: 1200 }}>
-          <Work {...initialData} />
+          <Work {...initialData} writtenBy={initialData?.author} />
         </ContentLayout>
       </Layout>
       {isDocumentOpen && (

--- a/puppetplays-web/public/locales/en/common.json
+++ b/puppetplays-web/public/locales/en/common.json
@@ -62,7 +62,7 @@
   "close": "Close",
   "closeNote": "Close the overview",
   "expandNote": "Open the overview",
-  "writtenBy": "Written by",
+  "writtenBy": "Contributor",
   "translatedBy": "Translator",
   "alias": "alias",
   "language": "Language",

--- a/puppetplays-web/public/locales/fr/common.json
+++ b/puppetplays-web/public/locales/fr/common.json
@@ -63,7 +63,7 @@
   "close": "Fermer",
   "closeNote": "Refermer l'aperçu'",
   "expandNote": "Ouvrir l'aperçu",
-  "writtenBy": "Écrit par",
+  "writtenBy": "Contributeur",
   "translatedBy": "Traduit par",
   "alias": "alias",
   "language": "Langue",


### PR DESCRIPTION
Display the Craft CMS user who created/published the work notice as a contributor. The contributor section is now displayed before the translator section.

- Add author field to GraphQL query in getWorkById
- Pass author data to Work component via writtenBy prop
- Update translations: "Written by" → "Contributor" (EN), "Écrit par" → "Contributeur" (FR)
- Reorder sections: Contributor now appears before Translator